### PR TITLE
Initial project setup with docs and CI workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+- Brief overview of changes
+
+## Why
+- Reason/motivation for the change
+
+## Changes
+- Bulleted list of files/areas touched
+
+## Screenshots
+<!-- optional -->
+
+## How to test locally
+```bash
+# For Jekyll sites
+bundle install
+bundle exec jekyll serve --livereload
+
+# For static sites
+python -m http.server 4000
+# or
+npx http-server -p 4000 -c-1
+```
+
+## Checklist
+- [ ] Builds locally without errors
+- [ ] Content and links reviewed
+- [ ] Spelling/grammar pass
+- [ ] Licensing notes updated where applicable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install --path vendor/bundle
+      - name: Build site
+        run: bundle exec jekyll build --trace

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Marc MacArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-content
+++ b/LICENSE-content
@@ -1,0 +1,7 @@
+Content License — Creative Commons BY-NC-SA-4.0
+
+Except where noted otherwise, the content of this repository (text, images, charts, audio, PDFs, data files)
+is licensed under **CC BY-NC-SA-4.0**.
+
+Summary: see https://creativecommons.org/licenses/by/nc-sa-4.0/
+Legal code: https://creativecommons.org/licenses/by/nc-sa-4.0/legalcode

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Gospel From Gravel Hill — Website
+
+[![Last Commit](https://img.shields.io/github/last-commit/gospelfromgravelhill/gospelfromgravelhill.github.io?logo=github)](https://github.com/gospelfromgravelhill/gospelfromgravelhill.github.io/commits/main)
+![Made with Jekyll](https://img.shields.io/badge/Made%20with-Jekyll-%23cc0000)
+![GitHub Pages](https://img.shields.io/badge/Hosted%20on-GitHub%20Pages-222)
+[![Pages Build](https://github.com/gospelfromgravelhill/gospelfromgravelhill.github.io/actions/workflows/pages/pages-build-deployment/badge.svg?branch=main)](https://github.com/gospelfromgravelhill/gospelfromgravelhill.github.io/actions/workflows/pages/pages-build-deployment)
+[![CI](https://github.com/gospelfromgravelhill/gospelfromgravelhill.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/gospelfromgravelhill/gospelfromgravelhill.github.io/actions/workflows/ci.yml)
+![Code License](https://img.shields.io/badge/Code%20License-MIT-green)
+![Content License](https://img.shields.io/badge/Content%20License-CC%20BY--NC--SA%204.0-blue)
+
+> “…the glorious gospel of the blessed God…” — 1 Timothy 1:11
+
+A structured Jekyll site with sections for **Articles**, **Audio**, **Books**, **Charts**, **Tracts**, and built‑in client‑side search.
+
+## 📁 Structure
+- Jekyll: `_includes/`, `_layouts/`, `_posts/`, `_sass/`, `_config.yml`, `Gemfile`
+- Pages: `index.html`, `about.md`, `articles.md`, `audio.md`, `books.md`, `charts.md`, `tracts.md`, `recent.md`, `thank-you.md`, `404.html`
+- Search: `search.md`, `search.json`
+- Assets: `assets/`
+- Node (asset tooling): `package.json`, `package-lock.json`
+- Custom domain via `CNAME`
+
+## ✍️ Editing Content
+- **Posts**: add to `_posts/` with standard Jekyll front matter.
+- **Sections**: update the respective `*.md` pages; many layouts live under `_layouts/` and `_includes/`.
+- **Search index**: if you modify collections, ensure `search.json` generation still includes desired fields.
+
+## 🧪 Run Locally
+
+> **Prereqs**: Ruby + Bundler, and Node (LTS).
+
+```bash
+# Ruby deps
+gem install bundler
+bundle install
+
+# Node deps (if used by the theme/tooling)
+npm ci  # or: npm install
+
+# Serve the site
+bundle exec jekyll serve --livereload
+# Then open http://127.0.0.1:4000
+```
+
+## Licensing
+- **Code**: MIT — see `LICENSE`.
+- **Content**: CC BY-NC-SA 4.0 — see `LICENSE-content`.

--- a/_site-snippets/github-url-shortening.md
+++ b/_site-snippets/github-url-shortening.md
@@ -1,0 +1,100 @@
+# GitHub Pages (Commit-Driven Shortlinks)
+
+**How it works**  
+Each short link is just a folder with an `index.html` file that redirects instantly.  
+A GitHub Action creates/updates these redirect pages when you trigger it.
+
+**Pros:**  
+- 100% free (no extra infrastructure).  
+- Works with your custom domain.  
+
+**Cons:**  
+- Each new link requires a commit (a few seconds to deploy).
+
+### Folder Layout
+```
+/s/hello-world/index.html   -> redirects to your long URL
+```
+
+### Redirect Template
+```html
+<!doctype html><meta charset="utf-8">
+<link rel="canonical" href="$TARGET">
+<meta http-equiv="refresh" content="0; url=$TARGET">
+<title>Redirecting…</title>
+<a href="$TARGET">Click here if not redirected</a>
+<script>location.replace("$TARGET");</script>
+```
+
+### GitHub Action: Create Shortlink
+Save this as `.github/workflows/create-shortlink.yml`.
+
+```yaml
+name: Create shortlink
+on:
+  workflow_dispatch:
+    inputs:
+      slug: { description: "Slug (e.g. hello)", required: true }
+      url:  { description: "Destination URL", required: true }
+      title:{ description: "Optional page title", required: false }
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  make:
+    if: github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'issue_comment' &&
+         startsWith(github.event.comment.body, '/shorten '))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse inputs (slash command supported)
+        id: parse
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            BODY="${{ github.event.comment.body }}"
+            SLUG=$(echo "$BODY" | awk '{print $2}')
+            URL=$(echo  "$BODY" | awk '{print $3}')
+            TITLE=$(echo "$BODY" | cut -d' ' -f4-)
+          else
+            SLUG="${{ github.event.inputs.slug }}"
+            URL="${{ github.event.inputs.url }}"
+            TITLE="${{ github.event.inputs.title }}"
+          fi
+          echo "slug=$SLUG"   >> $GITHUB_OUTPUT
+          echo "url=$URL"     >> $GITHUB_OUTPUT
+          echo "title=$TITLE" >> $GITHUB_OUTPUT
+
+      - name: Create redirect page
+        run: |
+          mkdir -p "s/${{ steps.parse.outputs.slug }}"
+          TPL='<!doctype html><meta charset="utf-8">
+<link rel="canonical" href="$TARGET">
+<meta http-equiv="refresh" content="0; url=$TARGET">
+<title>${{ steps.parse.outputs.title || 'Redirecting…' }}</title>
+<a href="$TARGET">Click here if not redirected</a>
+<script>location.replace("$TARGET");</script>'
+          echo "${TPL//\$TARGET/${{ steps.parse.outputs.url }}}" > "s/${{ steps.parse.outputs.slug }}/index.html"
+
+      - name: Commit
+        run: |
+          git config user.name  "shortlink-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add "s/${{ steps.parse.outputs.slug }}/index.html"
+          git commit -m "short: ${{ steps.parse.outputs.slug }} -> ${{ steps.parse.outputs.url }}" || echo "No changes"
+          git push
+```
+
+**Usage**
+- Manual: Trigger from **Actions → Create shortlink**.  
+- Issue/PR comment: `/shorten hello https://example.com/long/path`
+
+The short link will be:  
+```
+https://yourdomain/s/hello
+```
+
+---


### PR DESCRIPTION
Add project documentation (README, licenses), GitHub Actions CI workflow, pull request template, and a site snippet for GitHub URL shortening. This establishes repository structure, licensing, contribution guidelines, and automated build for a Jekyll-based site.