### PR TITLE
Update Sussex Conference post date to October 3, 2025

### DIFF
--- a/_posts/audio/2025-Conference/2025-10-03-2025-Sussex-Conference.md
+++ b/_posts/audio/2025-Conference/2025-10-03-2025-Sussex-Conference.md
@@ -1,7 +1,7 @@
 ---
 layout: redirect
-title: "2025-09-03 - 2025 Sussex Conference"
-date: 2025-09-03
+title: "2025-10-03 - 2025 Sussex Conference"
+date: 2025-10-03
 category: 2025conference
 redirect_url: "https://olearygospelhall.ca/2025/10/04/2025-sussex-conference/"
 ---


### PR DESCRIPTION
Renamed and updated the conference post to reflect the new date of October 3, 2025, ensuring accurate event information.
